### PR TITLE
删除独立上游的编译

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,45 +46,10 @@ jobs:
           
       - uses: actions/upload-artifact@v4
         with:
-          name: Lingmo Artifacts trixie
-          path: BuildArtifacts
-          compression-level: 9 # maximum compression
-
-  build-hydrogen:
-    runs-on: ubuntu-latest
-    container: ghcr.io/lingmoos-testing/lingmo:hydrogen-slim
-    name: Build Hydrogen
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Update Lingmo repo
-        run: |
-          apt-get update -y && apt-get upgrade -y && apt-get install -y apt-transport-https ca-certificates
-          echo "deb [trusted=yes] https://packages.lingmo.org/packages hydrogen main contrib non-free non-free-firmware" > /etc/apt/sources.list
-          apt-get update
-
-      - name: Update Apt and Install packages
-        run: |
-          apt-get update -y && apt-get upgrade -y
-          apt-get install -y sudo equivs curl git devscripts lintian build-essential automake autotools-dev cmake g++ --no-install-recommends
-
-      - name: Install PowerShell
-        run: |
-          curl -L https://github.com/PowerShell/PowerShell/releases/download/v7.4.3/powershell_7.4.3-1.deb_amd64.deb -o powershell.deb
-          apt-get install -y ./powershell.deb
-          rm powershell.deb
-      
-      - name: Build Lingmo
-        run: |
-          git config --global http.sslVerify false
-          git config --global advice.detachedHead false
-          pwsh ./build.ps1
-          
-      - uses: actions/upload-artifact@v4
-        with:
           name: Lingmo Artifacts hydrogen
           path: BuildArtifacts
           compression-level: 9 # maximum compression
+
 
   # upload:
   #   needs: build


### PR DESCRIPTION
因为上游跑路，所以暂时删除自有源https://packages.lingmo.org/的构建。